### PR TITLE
feat: Add login credentials note to login page

### DIFF
--- a/src/components/pages/LogIn.jsx
+++ b/src/components/pages/LogIn.jsx
@@ -77,6 +77,17 @@ const LogIn = () => {
         onSubmit={formik.handleSubmit}
         className="flex flex-col items-center gap-4 w-full max-w-xs mx-auto"
       >
+        <div className="mb-4 p-3 bg-gray-100 rounded-md">
+          <p className="text-sm text-gray-700">
+            For Vercel domain users:
+          </p>
+          <p className="text-sm text-gray-700">
+            Email: admin@gmail.com
+          </p>
+          <p className="text-sm text-gray-700">
+            Password: admin123
+          </p>
+        </div>
         <div className="w-full  space-y-1">
           <label htmlFor="email" className="block mb-1 text-foreground">
             {t("logIn.email")}


### PR DESCRIPTION
Added a note to the login page displaying email and password for Vercel domain users.

The note provides the following credentials:
- Email: admin@gmail.com
- Password: admin123

The note is styled using Tailwind CSS to match the existing theme and is placed above the email input field for visibility.